### PR TITLE
Foi adicionado suporte ao Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  nginx:
+    image: nginx:latest
+    container_name: nginx-container
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - php
+
+  php:
+    build:
+      context: .
+      dockerfile: php/Dockerfile
+    container_name: php-container
+    volumes:
+      - .:/var/www/html
+    depends_on:
+      - mysql
+
+
+  mysql:
+    image: mysql:8.0
+    container_name: mysql-container
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: my-secret-pw
+      MYSQL_DATABASE: crud
+      MYSQL_USER: user
+      MYSQL_PASSWORD: userpass
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  mysql-data:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /var/www/html;
+    index index.php index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME /var/www/html$fastcgi_script_name;
+    }
+}

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:8.2-fpm
+
+# Install mysqli extension
+RUN docker-php-ext-install mysqli
+
+# Optional: Enable other useful extensions
+# RUN docker-php-ext-install pdo pdo_mysql


### PR DESCRIPTION
Agora é possível fazer o projeto rodar usando containers para o PHP, Nginx e o MySQL. Dessa forma não é mais preciso instalar essas ferramentas manualmente.